### PR TITLE
Fix CONTRIBUTING.md to avoid error when running cargo build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,12 @@ This file is a WIP.
 
 ## Dependencies
 - [Flutter](https://docs.flutter.dev/get-started/install)
-- [rustup](https://rustup.rs)
-  - Run `cargo build -r` in the project root once installed
-    - Needed for the Dart tests to run
 - [Melos](https://melos.invertase.dev)
   - `dart pub global activate melos`
   - Run `melos bs` in the project root once installed
+- [rustup](https://rustup.rs)
+  - Run `cargo build -r` in the project root once installed
+    - Needed for the Dart tests to run
 - To build the Flutter binaries (which you only need to do if you choose to run Flutter integration tests locally):
   - macOS (at least for `build-apple.sh`)
   - [Android NDK](https://developer.android.com/ndk/downloads)


### PR DESCRIPTION
After a fresh checkout `melos bs` must be run first otherwise when running `cargo build -r` it fails for a missing pubspec.lock:

```
error: failed to run custom build command for `embedded_milli v0.0.0 ([redacted]/code/dart/mimir/packages/mimir/native)`

Caused by:
  process didn't exit successfully: `[redacted]/code/dart/mimir/target/release/build/embedded_milli-193bf6019fe04397/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=src/api.rs

  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: missing pubspec.lock in [redacted]/code/dart/mimir/packages/mimir/native/..', packages/mimir/native/build.rs:32:43
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```