### PR TITLE
fix: partial fix of #227 for iPhone 7s

### DIFF
--- a/packages/mimir/native/src/embedded_milli.rs
+++ b/packages/mimir/native/src/embedded_milli.rs
@@ -33,7 +33,7 @@ type Dump = (MimirIndexSettings, Vec<Document>);
 // Then, we find the maximum multiple of MAX_OS_PAGE_SIZE that is less than MAX_POSSIBLE_SIZE.
 // MAX_POSSIBLE_SIZE complies with memory constraints imposed by iOS without extra entitlements.
 const MAX_OS_PAGE_SIZE: usize = 16_777_216;
-const MAX_POSSIBLE_SIZE: usize = 2_000_000_000;
+const MAX_POSSIBLE_SIZE: usize = 1_500_000_000;
 const MAX_MAP_SIZE: usize = MAX_POSSIBLE_SIZE - (MAX_POSSIBLE_SIZE % MAX_OS_PAGE_SIZE);
 
 /// Defines what an embedded instance of milli should be able to do.


### PR DESCRIPTION
(hopefully) fixes a part of #227 for iPhone 7 compatibility by reducing the maximum map size (which isn't really a fix, but rather a temporary workaround).