### PR TITLE
fix: add 16kb config for Android 15

### DIFF
--- a/packages/mimir/native/build.rs
+++ b/packages/mimir/native/build.rs
@@ -1,8 +1,14 @@
+use cbindgen::Language;
 use std::env;
 
-use cbindgen::Language;
-
 fn main() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    if target_os == "android" && (target_arch == "aarch64" || target_arch == "x86_64") {
+        println!("cargo:rustc-link-arg=-Wl,-z,max-page-size=16384");
+    }
+
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
     cbindgen::Builder::new()


### PR DESCRIPTION
Hey, thanks for your awesome work on this package.

We recently ran into the 16 KB page size issue during our Android app review (which causes warnings for newer Android 15 devices). We managed to fix it by enforcing the 16 KB alignment via flags directly in the build.rs.

I thought I'd just leave this here, maybe you can use it or find it helpful for a future release.